### PR TITLE
feat(member-package): Implement CRUD operations for subscription packages

### DIFF
--- a/src/main/java/com/example/smoking_cessation_platform/config/SecurityConfig.java
+++ b/src/main/java/com/example/smoking_cessation_platform/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.smoking_cessation_platform.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -23,11 +24,17 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
+                        // api auth
                         .requestMatchers("/api/auth/register",
                                 "/api/auth/email/resend-otp",
                                 "/api/auth/email/verify",
                                 "/api/auth/google"
                         ).permitAll()
+                        // api memberpackage
+                        .requestMatchers(HttpMethod.GET, "/api/member-packages/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/member-packages").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/member-packages/**").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/member-packages/**").authenticated()
                         .anyRequest().authenticated()
                 );
         return http.build();

--- a/src/main/java/com/example/smoking_cessation_platform/controller/MemberPackageController.java
+++ b/src/main/java/com/example/smoking_cessation_platform/controller/MemberPackageController.java
@@ -1,0 +1,89 @@
+package com.example.smoking_cessation_platform.controller;
+
+import com.example.smoking_cessation_platform.dto.memberpackage.MemberPackageRequest;
+import com.example.smoking_cessation_platform.dto.memberpackage.MemberPackageResponse;
+import com.example.smoking_cessation_platform.service.MemberPackageService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/member-packages")
+public class MemberPackageController {
+
+    @Autowired
+    private MemberPackageService memberPackageService;
+
+    /**
+     * API để tạo một gói đăng ký mới.
+     * Yêu cầu: POST /api/member-packages
+     * Body: MemberPackageRequest (JSON)
+     * @param createDto DTO chứa thông tin gói cần tạo.
+     * @return ResponseEntity chứa DTO phản hồi hoặc thông báo lỗi.
+     */
+    @PostMapping
+    public ResponseEntity<MemberPackageResponse> createMemberPackage(@Valid @RequestBody MemberPackageRequest createDto) {
+        MemberPackageResponse newPackage = memberPackageService.createMemberPackage(createDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(newPackage);
+    }
+
+    /**
+     * API để lấy tất cả các gói đăng ký.
+     * Yêu cầu: GET /api/member-packages
+     * @return ResponseEntity chứa danh sách DTO phản hồi.
+     */
+    @GetMapping
+    public ResponseEntity<List<MemberPackageResponse>> getAllMemberPackages() {
+        List<MemberPackageResponse> packages = memberPackageService.getAllMemberPackages();
+        return ResponseEntity.ok(packages);
+    }
+
+    /**
+     * API để lấy một gói đăng ký theo ID.
+     * Yêu cầu: GET /api/member-packages/{id}
+     * @param id ID của gói đăng ký.
+     * @return ResponseEntity chứa DTO phản hồi hoặc NOT_FOUND nếu không tìm thấy.
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<MemberPackageResponse> getMemberPackageById(@PathVariable Integer id) {
+        Optional<MemberPackageResponse> memberPackage = memberPackageService.getMemberPackageById(id);
+        return memberPackage.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * API để cập nhật thông tin một gói đăng ký.
+     * Yêu cầu: PUT /api/member-packages/{id}
+     * Body: MemberPackageRequest (JSON)
+     * @param id ID của gói đăng ký cần cập nhật.
+     * @param updateDto DTO chứa thông tin cập nhật.
+     * @return ResponseEntity chứa DTO phản hồi hoặc NOT_FOUND nếu không tìm thấy.
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<MemberPackageResponse> updateMemberPackage(@PathVariable Integer id, @Valid @RequestBody MemberPackageRequest updateDto) {
+        Optional<MemberPackageResponse> updatedPackage = memberPackageService.updateMemberPackage(id, updateDto);
+        return updatedPackage.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * API để xóa một gói đăng ký theo ID.
+     * Yêu cầu: DELETE /api/member-packages/{id}
+     * @param id ID của gói đăng ký cần xóa.
+     * @return ResponseEntity chứa NO_CONTENT nếu xóa thành công, hoặc NOT_FOUND nếu không tìm thấy.
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteMemberPackage(@PathVariable Integer id) {
+        boolean deleted = memberPackageService.deleteMemberPackage(id);
+        if (deleted) {
+            return ResponseEntity.noContent().build(); // 204 NO_CONTENT
+        } else {
+            return ResponseEntity.notFound().build(); // 404 NOT_FOUND
+        }
+    }
+}

--- a/src/main/java/com/example/smoking_cessation_platform/dto/memberpackage/MemberPackageRequest.java
+++ b/src/main/java/com/example/smoking_cessation_platform/dto/memberpackage/MemberPackageRequest.java
@@ -1,0 +1,33 @@
+package com.example.smoking_cessation_platform.dto.memberpackage;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberPackageRequest {
+    @NotBlank(message = "Tên gói không được để trống")
+    @Size(max = 255, message = "Tên gói không được vượt quá 255 ký tự")
+    private String packageName;
+
+    @NotNull(message = "Giá không được để trống")
+    @Positive(message = "Giá phải là số dương")
+    private BigDecimal price;
+
+    @NotNull(message = "Thời lượng không được để trống")
+    @Positive(message = "Thời lượng phải là số dương")
+    private Integer duration;
+
+    @Size(max = 65535, message = "Mô tả tính năng quá dài")
+    private String featuresDescription;
+}

--- a/src/main/java/com/example/smoking_cessation_platform/dto/memberpackage/MemberPackageResponse.java
+++ b/src/main/java/com/example/smoking_cessation_platform/dto/memberpackage/MemberPackageResponse.java
@@ -1,0 +1,25 @@
+package com.example.smoking_cessation_platform.dto.memberpackage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberPackageResponse {
+
+    private Integer memberPackageId;
+
+    private String packageName;
+
+    private BigDecimal price;
+
+    private Integer duration;
+
+    private String featuresDescription;
+}

--- a/src/main/java/com/example/smoking_cessation_platform/entity/MemberPackage.java
+++ b/src/main/java/com/example/smoking_cessation_platform/entity/MemberPackage.java
@@ -48,4 +48,13 @@ public class MemberPackage implements Serializable {
     @OneToMany(mappedBy = "memberPackage", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Set<UserMemberPackage> userMemberPackages = new HashSet<>();
 
+    public void addUserMemberPackage(UserMemberPackage userMemberPackage) {
+        this.userMemberPackages.add(userMemberPackage);
+        userMemberPackage.setMemberPackage(this);
+    }
+
+    public void removeUserMemberPackage(UserMemberPackage userMemberPackage) {
+        this.userMemberPackages.remove(userMemberPackage);
+        userMemberPackage.setMemberPackage(null);
+    }
 }

--- a/src/main/java/com/example/smoking_cessation_platform/repository/MemberPackageRepository.java
+++ b/src/main/java/com/example/smoking_cessation_platform/repository/MemberPackageRepository.java
@@ -2,8 +2,10 @@ package com.example.smoking_cessation_platform.repository;
 
 import com.example.smoking_cessation_platform.entity.MemberPackage;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
 
-public interface MemberPackageRepository extends JpaRepository<MemberPackage, Integer>, JpaSpecificationExecutor<MemberPackage> {
+
+@Repository
+public interface MemberPackageRepository extends JpaRepository<MemberPackage, Integer> {
 
 }

--- a/src/main/java/com/example/smoking_cessation_platform/service/MemberPackageService.java
+++ b/src/main/java/com/example/smoking_cessation_platform/service/MemberPackageService.java
@@ -1,0 +1,109 @@
+package com.example.smoking_cessation_platform.service;
+
+import com.example.smoking_cessation_platform.entity.MemberPackage;
+import com.example.smoking_cessation_platform.dto.memberpackage.MemberPackageRequest;
+import com.example.smoking_cessation_platform.dto.memberpackage.MemberPackageResponse;
+import com.example.smoking_cessation_platform.repository.MemberPackageRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class MemberPackageService {
+
+    @Autowired
+    private MemberPackageRepository memberPackageRepository;
+
+    /**
+     * Tạo một gói đăng ký mới.
+     * @param createDto DTO chứa thông tin gói cần tạo.
+     * @return DTO phản hồi của gói đã được tạo.
+     */
+    @Transactional
+    public MemberPackageResponse createMemberPackage(MemberPackageRequest createDto) {
+        MemberPackage memberPackage = MemberPackage.builder()
+                .packageName(createDto.getPackageName())
+                .price(createDto.getPrice())
+                .duration(createDto.getDuration())
+                .featuresDescription(createDto.getFeaturesDescription())
+                .build();
+
+        MemberPackage savedPackage = memberPackageRepository.save(memberPackage);
+
+        return convertToDto(savedPackage);
+    }
+
+    /**
+     * Lấy tất cả các gói đăng ký.
+     * @return Danh sách các DTO phản hồi của gói đăng ký.
+     */
+    public List<MemberPackageResponse> getAllMemberPackages() {
+        List<MemberPackage> memberPackages = memberPackageRepository.findAll();
+        return memberPackages.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Lấy một gói đăng ký theo ID.
+     * @param id ID của gói đăng ký.
+     * @return Optional chứa DTO phản hồi của gói (nếu tìm thấy).
+     */
+    public Optional<MemberPackageResponse> getMemberPackageById(Integer id) {
+        return memberPackageRepository.findById(id)
+                .map(this::convertToDto);
+    }
+
+    /**
+     * Cập nhật thông tin một gói đăng ký.
+     * @param id ID của gói đăng ký cần cập nhật.
+     * @param updateDto DTO chứa thông tin cập nhật.
+     * @return Optional chứa DTO phản hồi của gói đã cập nhật (nếu tìm thấy).
+     */
+    @Transactional
+    public Optional<MemberPackageResponse> updateMemberPackage(Integer id, MemberPackageRequest updateDto) {
+        return memberPackageRepository.findById(id)
+                .map(existingPackage -> {
+                    existingPackage.setPackageName(updateDto.getPackageName());
+                    existingPackage.setPrice(updateDto.getPrice());
+                    existingPackage.setDuration(updateDto.getDuration());
+                    existingPackage.setFeaturesDescription(updateDto.getFeaturesDescription());
+
+                    MemberPackage updatedPackage = memberPackageRepository.save(existingPackage);
+                    return convertToDto(updatedPackage);
+                });
+    }
+
+    /**
+     * Xóa một gói đăng ký theo ID.
+     * @param id ID của gói đăng ký cần xóa.
+     * @return true nếu xóa thành công, false nếu không tìm thấy gói.
+     */
+    @Transactional
+    public boolean deleteMemberPackage(Integer id) {
+        if (memberPackageRepository.existsById(id)) {
+            memberPackageRepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Phương thức hỗ trợ chuyển đổi từ Entity MemberPackage sang MemberPackageResponseDTO.
+     * @param memberPackage Entity MemberPackage.
+     * @return MemberPackageResponseDTO.
+     */
+    private MemberPackageResponse convertToDto(MemberPackage memberPackage) {
+        return MemberPackageResponse.builder()
+                .memberPackageId(memberPackage.getMemberPackageId())
+                .packageName(memberPackage.getPackageName())
+                .price(memberPackage.getPrice())
+                .duration(memberPackage.getDuration())
+                .featuresDescription(memberPackage.getFeaturesDescription())
+                .build();
+    }
+}


### PR DESCRIPTION
This commit introduces full CRUD (Create, Read, Update, Delete) functionality for managing MemberPackage entities, representing the subscription packages offered by the platform.

Key features implemented:
- API endpoint to create a new subscription package (POST /api/member-packages).
- API endpoint to retrieve all subscription packages (GET /api/member-packages).
- API endpoint to retrieve a specific subscription package by ID (GET /api/member-packages/{id}).
- API endpoint to update an existing subscription package (PUT /api/member-packages/{id}).
- API endpoint to delete a subscription package by ID (DELETE /api/member-packages/{id}).

New components introduced:
- `MemberPackageRequest`: DTO for creating and updating package data, with validation.
- `MemberPackageResponse`: DTO for returning package information in API responses.
- `MemberPackageService`: Business logic for CRUD operations.
- `MemberPackageRepository`: JPA repository for database interaction.
- `MemberPackageController`: REST controller exposing package management APIs.

Security configuration updated:
- GET requests to `/api/member-packages/**` are publicly accessible (`permitAll()`).
- POST, PUT, DELETE requests to `/api/member-packages/**` require authentication (`authenticated()`), setting up for future role-based authorization.