### PR TITLE
feat(post-comment): Implement Post and Comment management

### DIFF
--- a/src/main/java/com/example/smoking_cessation_platform/controller/CommentController.java
+++ b/src/main/java/com/example/smoking_cessation_platform/controller/CommentController.java
@@ -1,0 +1,135 @@
+package com.example.smoking_cessation_platform.controller;
+
+import com.example.smoking_cessation_platform.dto.comment.CommentRequest;
+import com.example.smoking_cessation_platform.dto.comment.CommentResponse;
+import com.example.smoking_cessation_platform.service.CommentService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import com.example.smoking_cessation_platform.security.CustomUserDetails;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/posts/{postId}/comments")
+public class CommentController {
+
+    @Autowired
+    private CommentService commentService;
+
+    /**
+     * API để tạo một bình luận mới cho một bài viết.
+     * Yêu cầu: POST /api/posts/{postId}/comments
+     * Body: CommentRequest (JSON)
+     * API này yêu cầu người dùng đã được xác thực.
+     * @param postId ID của bài viết mà bình luận thuộc về.
+     * @param createDto DTO chứa thông tin bình luận cần tạo.
+     * @param authentication Đối tượng Authentication từ Spring Security.
+     * @return ResponseEntity chứa DTO phản hồi của bình luận đã được tạo.
+     */
+    @PostMapping
+    public ResponseEntity<CommentResponse> createComment(@PathVariable Integer postId, @Valid @RequestBody CommentRequest createDto, Authentication authentication) {
+        Long currentUserId = null;
+        if (authentication.getPrincipal() instanceof CustomUserDetails) {
+            currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        } else {
+            System.err.println("Principal type is not CustomUserDetails for createComment. Current type: " + authentication.getPrincipal().getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+
+        try {
+            CommentResponse newComment = commentService.createComment(postId, createDto, currentUserId);
+            return ResponseEntity.status(HttpStatus.CREATED).body(newComment);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
+    }
+
+    /**
+     * API để lấy tất cả bình luận cho một bài viết cụ thể.
+     * Yêu cầu: GET /api/posts/{postId}/comments
+     * @param postId ID của bài viết.
+     * @return ResponseEntity chứa danh sách DTO phản hồi của bình luận.
+     */
+    @GetMapping
+    public ResponseEntity<List<CommentResponse>> getCommentsByPostId(@PathVariable Integer postId) {
+        List<CommentResponse> comments = commentService.getCommentsByPostId(postId);
+        return ResponseEntity.ok(comments);
+    }
+
+    /**
+     * API để lấy một bình luận theo ID.
+     * Yêu cầu: GET /api/posts/{postId}/comments/{commentId}
+     * @param commentId ID của bình luận.
+     * @return ResponseEntity chứa DTO phản hồi bình luận hoặc NOT_FOUND.
+     */
+    @GetMapping("/{commentId}")
+    public ResponseEntity<CommentResponse> getCommentById(@PathVariable Integer commentId) {
+        Optional<CommentResponse> comment = commentService.getCommentById(commentId);
+        return comment.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * API để cập nhật thông tin một bình luận.
+     * Yêu cầu: PUT /api/posts/{postId}/comments/{commentId}
+     * Body: CommentRequest (JSON)
+     * API này yêu cầu người dùng đã được xác thực và là chủ sở hữu bình luận.
+     * @param commentId ID của bình luận cần cập nhật.
+     * @param updateDto DTO chứa thông tin cập nhật.
+     * @param authentication Đối tượng Authentication từ Spring Security.
+     * @return ResponseEntity chứa DTO phản hồi bình luận đã cập nhật hoặc thông báo lỗi.
+     */
+    @PutMapping("/{commentId}")
+    public ResponseEntity<CommentResponse> updateComment(@PathVariable Integer commentId, @Valid @RequestBody CommentRequest updateDto, Authentication authentication) {
+        Long currentUserId = null;
+        if (authentication.getPrincipal() instanceof CustomUserDetails) {
+            currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        } else {
+            System.err.println("Principal type is not CustomUserDetails for updateComment. Current type: " + authentication.getPrincipal().getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+
+        try {
+            Optional<CommentResponse> updatedComment = commentService.updateComment(commentId, updateDto, currentUserId);
+            return updatedComment.map(ResponseEntity::ok)
+                    .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null); // 403 Forbidden
+        }
+    }
+
+    /**
+     * API để xóa một bình luận.
+     * Yêu cầu: DELETE /api/posts/{postId}/comments/{commentId}
+     * API này yêu cầu người dùng đã được xác thực và là chủ sở hữu bình luận.
+     * @param commentId ID của bình luận cần xóa.
+     * @param authentication Đối tượng Authentication từ Spring Security.
+     * @return ResponseEntity chứa NO_CONTENT nếu xóa thành công, hoặc NOT_FOUND.
+     */
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Integer commentId, Authentication authentication) {
+        Long currentUserId = null;
+        if (authentication.getPrincipal() instanceof CustomUserDetails) {
+            currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        } else {
+            System.err.println("Principal type is not CustomUserDetails for deleteComment. Current type: " + authentication.getPrincipal().getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        try {
+            boolean deleted = commentService.deleteComment(commentId, currentUserId);
+            if (deleted) {
+                return ResponseEntity.noContent().build();
+            } else {
+                return ResponseEntity.notFound().build();
+            }
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build(); // 403 Forbidden
+        }
+    }
+}

--- a/src/main/java/com/example/smoking_cessation_platform/controller/PostController.java
+++ b/src/main/java/com/example/smoking_cessation_platform/controller/PostController.java
@@ -1,0 +1,148 @@
+package com.example.smoking_cessation_platform.controller;
+
+import com.example.smoking_cessation_platform.dto.post.PostRequest;
+import com.example.smoking_cessation_platform.dto.post.PostResponse;
+import com.example.smoking_cessation_platform.service.PostService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import com.example.smoking_cessation_platform.security.CustomUserDetails;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/posts")
+public class PostController {
+
+    @Autowired
+    private PostService postService;
+
+    /**
+     * API để tạo một bài viết mới.
+     * Yêu cầu: POST /api/posts
+     * Body: PostCreateUpdateDTO (JSON)
+     * API này yêu cầu người dùng đã được xác thực (đăng nhập).
+     * @param createDto DTO chứa thông tin bài viết cần tạo.
+     * @return ResponseEntity chứa DTO phản hồi của bài viết đã được tạo.
+     */
+    @PostMapping
+    public ResponseEntity<PostResponse> createPost(@Valid @RequestBody PostRequest createDto) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long currentUserId = null;
+        if (authentication.getPrincipal() instanceof CustomUserDetails) {
+            currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        } else {
+            System.err.println("Principal type is not CustomUserDetails for createPost. Current type: " + authentication.getPrincipal().getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+
+        try {
+            PostResponse newPost = postService.createPost(createDto, currentUserId);
+            return ResponseEntity.status(HttpStatus.CREATED).body(newPost);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
+    }
+
+    /**
+     * API để lấy tất cả các bài viết công khai.
+     * Yêu cầu: GET /api/posts
+     * @return ResponseEntity chứa danh sách DTO phản hồi bài viết.
+     */
+    @GetMapping
+    public ResponseEntity<List<PostResponse>> getAllPublishedPosts() {
+        List<PostResponse> posts = postService.getAllPublishedPosts();
+        return ResponseEntity.ok(posts);
+    }
+
+    /**
+     * API để lấy một bài viết theo ID.
+     * Yêu cầu: GET /api/posts/{postId}
+     * @param postId ID của bài viết.
+     * @return ResponseEntity chứa DTO phản hồi bài viết hoặc NOT_FOUND.
+     */
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponse> getPostById(@PathVariable Integer postId) {
+        Optional<PostResponse> post = postService.getPostById(postId);
+        return post.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * API để lấy tất cả bài viết của một người dùng cụ thể.
+     * Yêu cầu: GET /api/posts/user/{userId}
+     * @param userId ID của người dùng.
+     * @return ResponseEntity chứa danh sách DTO phản hồi bài viết của người dùng đó.
+     */
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<PostResponse>> getPostsByUserId(@PathVariable Long userId) {
+        List<PostResponse> posts = postService.getPostsByUserId(userId);
+        return ResponseEntity.ok(posts);
+    }
+
+    /**
+     * API để cập nhật thông tin một bài viết.
+     * Yêu cầu: PUT /api/posts/{postId}
+     * Body: PostCreateUpdateDTO (JSON)
+     * API này yêu cầu người dùng đã được xác thực và là chủ sở hữu bài viết hoặc Admin.
+     * @param postId ID của bài viết cần cập nhật.
+     * @param updateDto DTO chứa thông tin cập nhật.
+     * @return ResponseEntity chứa DTO phản hồi bài viết đã cập nhật hoặc thông báo lỗi.
+     */
+    @PutMapping("/{postId}")
+    public ResponseEntity<PostResponse> updatePost(@PathVariable Integer postId, @Valid @RequestBody PostRequest updateDto) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long currentUserId = null;
+        if (authentication.getPrincipal() instanceof CustomUserDetails) {
+            currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        } else {
+            System.err.println("Principal type is not CustomUserDetails for updatePost. Current type: " + authentication.getPrincipal().getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+
+        try {
+            Optional<PostResponse> updatedPost = postService.updatePost(postId, updateDto, currentUserId);
+            return updatedPost.map(ResponseEntity::ok)
+                    .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()); // 404
+        } catch (RuntimeException e) {
+
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null); // 403
+        }
+    }
+
+    /**
+     * API để xóa một bài viết (thực hiện xóa mềm bằng cách thay đổi trạng thái).
+     * Yêu cầu: DELETE /api/posts/{postId}
+     * API này yêu cầu người dùng đã được xác thực và là chủ sở hữu bài viết hoặc Admin.
+     * @param postId ID của bài viết cần xóa.
+     * @return ResponseEntity chứa NO_CONTENT nếu xóa thành công, hoặc NOT_FOUND.
+     */
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable Integer postId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long currentUserId = null;
+        if (authentication.getPrincipal() instanceof CustomUserDetails) {
+            currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        } else {
+            System.err.println("Principal type is not CustomUserDetails for deletePost. Current type: " + authentication.getPrincipal().getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        try {
+            boolean deleted = postService.deletePost(postId, currentUserId);
+            if (deleted) {
+                return ResponseEntity.noContent().build(); // 204 No Content
+            } else {
+                return ResponseEntity.notFound().build(); // 404 Not Found
+            }
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build(); // 403 for bidden
+        }
+    }
+}

--- a/src/main/java/com/example/smoking_cessation_platform/dto/comment/CommentRequest.java
+++ b/src/main/java/com/example/smoking_cessation_platform/dto/comment/CommentRequest.java
@@ -1,0 +1,23 @@
+package com.example.smoking_cessation_platform.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentRequest {
+    @NotBlank(message = "Nội dung bình luận không được để trống")
+    @Size(max = 65535, message = "Nội dung bình luận quá dài")
+    private String content;
+
+    // status (active, deleted)
+    // default active
+    @Size(max = 20, message = "Trạng thái không hợp lệ")
+    private String status;
+}

--- a/src/main/java/com/example/smoking_cessation_platform/dto/comment/CommentResponse.java
+++ b/src/main/java/com/example/smoking_cessation_platform/dto/comment/CommentResponse.java
@@ -1,0 +1,22 @@
+package com.example.smoking_cessation_platform.dto.comment;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentResponse {
+    private Integer commentId;
+    private String content;
+    private LocalDateTime commentDate;
+    private String status; // (active, deleted)
+    private Integer postId;
+    private Long userId;
+    private String userName;
+}

--- a/src/main/java/com/example/smoking_cessation_platform/dto/post/PostRequest.java
+++ b/src/main/java/com/example/smoking_cessation_platform/dto/post/PostRequest.java
@@ -1,0 +1,30 @@
+package com.example.smoking_cessation_platform.dto.post;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostRequest {
+
+    @NotBlank(message = "Tiêu đề không được để trống")
+    @Size(max = 255, message = "Tiêu đề không được vượt quá 255 ký tự")
+    private String title;
+
+    @NotBlank(message = "Nội dung không được để trống")
+    @Size(max = 65535, message = "Nội dung bài viết quá dài")
+    private String content;
+
+    // status (published, deleted)
+    // default published
+    @Size(max = 20, message = "Trạng thái không hợp lệ")
+    private String status;
+
+
+}

--- a/src/main/java/com/example/smoking_cessation_platform/dto/post/PostResponse.java
+++ b/src/main/java/com/example/smoking_cessation_platform/dto/post/PostResponse.java
@@ -1,0 +1,23 @@
+package com.example.smoking_cessation_platform.dto.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostResponse {
+
+    private Integer postId;
+    private String title;
+    private String content;
+    private LocalDateTime postDate;
+    private String status;     // status (published, deleted)
+    private Long userId;
+    private String userName;
+}

--- a/src/main/java/com/example/smoking_cessation_platform/repository/CommentRepository.java
+++ b/src/main/java/com/example/smoking_cessation_platform/repository/CommentRepository.java
@@ -2,8 +2,12 @@ package com.example.smoking_cessation_platform.repository;
 
 import com.example.smoking_cessation_platform.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
 
-public interface CommentRepository extends JpaRepository<Comment, Integer>, JpaSpecificationExecutor<Comment> {
+import java.util.List;
 
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Integer> {
+    List<Comment> findByPost_PostId(Integer postId);
+    List<Comment> findByUser_UserId(Long userId);
 }

--- a/src/main/java/com/example/smoking_cessation_platform/repository/PostRepository.java
+++ b/src/main/java/com/example/smoking_cessation_platform/repository/PostRepository.java
@@ -2,8 +2,13 @@ package com.example.smoking_cessation_platform.repository;
 
 import com.example.smoking_cessation_platform.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
 
-public interface PostRepository extends JpaRepository<Post, Integer>, JpaSpecificationExecutor<Post> {
+import java.util.List;
 
+@Repository
+public interface PostRepository extends JpaRepository<Post, Integer> {
+    List<Post> findByUser_UserId(Long userId);
+    List<Post> findByStatus(String status);
+    List<Post> findByStatusNot(String status);
 }

--- a/src/main/java/com/example/smoking_cessation_platform/service/CommentService.java
+++ b/src/main/java/com/example/smoking_cessation_platform/service/CommentService.java
@@ -1,0 +1,154 @@
+package com.example.smoking_cessation_platform.service;
+
+import com.example.smoking_cessation_platform.entity.Comment;
+import com.example.smoking_cessation_platform.entity.Post;
+import com.example.smoking_cessation_platform.entity.User;
+import com.example.smoking_cessation_platform.dto.comment.CommentRequest;
+import com.example.smoking_cessation_platform.dto.comment.CommentResponse;
+import com.example.smoking_cessation_platform.repository.CommentRepository;
+import com.example.smoking_cessation_platform.repository.PostRepository;
+import com.example.smoking_cessation_platform.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class CommentService {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    /**
+     * Tạo một bình luận mới cho một bài viết.
+     * API này yêu cầu người dùng đã được xác thực (đăng nhập).
+     * @param postId ID của bài viết.
+     * @param createDto DTO chứa thông tin bình luận cần tạo.
+     * @param userId ID của người dùng tạo bình luận (lấy từ ngữ cảnh bảo mật).
+     * @return DTO phản hồi của bình luận đã được tạo.
+     */
+    @Transactional
+    public CommentResponse createComment(Integer postId, CommentRequest createDto, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Người dùng không tồn tại."));
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("Bài viết không tồn tại."));
+
+        Comment comment = Comment.builder()
+                .content(createDto.getContent())
+                .commentDate(LocalDateTime.now())
+                .status(createDto.getStatus() != null ? createDto.getStatus() : "active")
+                .user(user)
+                .post(post)
+                .build();
+
+        Comment savedComment = commentRepository.save(comment);
+        return convertToDto(savedComment);
+    }
+
+    /**
+     * Lấy tất cả bình luận cho một bài viết cụ thể.
+     * @param postId ID của bài viết.
+     * @return Danh sách DTO phản hồi của bình luận.
+     */
+    public List<CommentResponse> getCommentsByPostId(Integer postId) {
+        postRepository.findById(postId).orElseThrow(() -> new RuntimeException("Bài viết không tồn tại."));
+        return commentRepository.findByPost_PostId(postId).stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Lấy tất cả bình luận của một người dùng cụ thể.
+     * @param userId ID của người dùng.
+     * @return Danh sách DTO phản hồi của bình luận đó.
+     */
+    public List<CommentResponse> getCommentsByUserId(Long userId) {
+        userRepository.findById(userId).orElseThrow(() -> new RuntimeException("Người dùng không tồn tại."));
+        return commentRepository.findByUser_UserId(userId).stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Lấy một bình luận theo ID.
+     * @param commentId ID của bình luận.
+     * @return Optional chứa DTO phản hồi bình luận (nếu tìm thấy).
+     */
+    public Optional<CommentResponse> getCommentById(Integer commentId) {
+        return commentRepository.findById(commentId)
+                .map(this::convertToDto);
+    }
+
+    /**
+     * Cập nhật thông tin một bình luận.
+     * API này yêu cầu người dùng đã được xác thực và là chủ sở hữu bình luận.
+     * @param commentId ID của bình luận cần cập nhật.
+     * @param updateDto DTO chứa thông tin cập nhật.
+     * @param currentUserId ID của người dùng hiện tại (lấy từ ngữ cảnh bảo mật để kiểm tra quyền sở hữu).
+     * @return Optional chứa DTO phản hồi bình luận đã cập nhật (nếu tìm thấy).
+     */
+    @Transactional
+    public Optional<CommentResponse> updateComment(Integer commentId, CommentRequest updateDto, Long currentUserId) {
+        return commentRepository.findById(commentId)
+                .map(existingComment -> {
+                    if (!existingComment.getUser().getUserId().equals(currentUserId)) {
+                        throw new RuntimeException("Bạn không có quyền sửa bình luận này.");
+                    }
+
+                    existingComment.setContent(updateDto.getContent());
+                    existingComment.setStatus(updateDto.getStatus() != null ? updateDto.getStatus() : existingComment.getStatus());
+
+                    Comment updatedComment = commentRepository.save(existingComment);
+                    return convertToDto(updatedComment);
+                });
+    }
+
+    /**
+     * Xóa một bình luận (thực hiện xóa mềm bằng cách thay đổi trạng thái).
+     * API này yêu cầu người dùng đã được xác thực và là chủ sở hữu bình luận.
+     * @param commentId ID của bình luận cần xóa.
+     * @param currentUserId ID của người dùng hiện tại (lấy từ ngữ cảnh bảo mật để kiểm tra quyền sở hữu, hoặc Admin/Mod).
+     * @return true nếu xóa thành công, false nếu không tìm thấy bình luận.
+     */
+    @Transactional
+    public boolean deleteComment(Integer commentId, Long currentUserId) {
+        return commentRepository.findById(commentId)
+                .map(comment -> {
+                    if (!comment.getUser().getUserId().equals(currentUserId)) {
+                        throw new RuntimeException("Bạn không có quyền xóa bình luận này.");
+                    }
+                    comment.setStatus("deleted");
+                    commentRepository.save(comment);
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    /**
+     * Phương thức hỗ trợ chuyển đổi từ Entity Comment sang CommentResponse.
+     * @param comment Entity Comment.
+     * @return CommentResponse.
+     */
+    private CommentResponse convertToDto(Comment comment) {
+        return CommentResponse.builder()
+                .commentId(comment.getCommentId())
+                .content(comment.getContent())
+                .commentDate(comment.getCommentDate())
+                .status(comment.getStatus())
+                .postId(comment.getPost().getPostId())
+                .userId(comment.getUser().getUserId())
+                .userName(comment.getUser().getUserName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/smoking_cessation_platform/service/PostService.java
+++ b/src/main/java/com/example/smoking_cessation_platform/service/PostService.java
@@ -1,0 +1,153 @@
+package com.example.smoking_cessation_platform.service;
+
+import com.example.smoking_cessation_platform.entity.Post;
+import com.example.smoking_cessation_platform.entity.User;
+import com.example.smoking_cessation_platform.dto.post.PostRequest;
+import com.example.smoking_cessation_platform.dto.post.PostResponse;
+import com.example.smoking_cessation_platform.repository.PostRepository;
+import com.example.smoking_cessation_platform.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class PostService {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    /**
+     * Tạo một bài viết mới.
+     * @param createDto DTO chứa thông tin bài viết cần tạo.
+     * @param userId ID của người dùng tạo bài viết (lấy từ ngữ cảnh bảo mật).
+     * @return DTO phản hồi của bài viết đã được tạo.
+     */
+    @Transactional
+    public PostResponse createPost(PostRequest createDto, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Người dùng không tồn tại."));
+
+        Post post = Post.builder()
+                .title(createDto.getTitle())
+                .content(createDto.getContent())
+                .postDate(LocalDateTime.now())
+                .status(createDto.getStatus() != null ? createDto.getStatus() : "published")
+                .user(user)
+                .build();
+
+        Post savedPost = postRepository.save(post);
+        return convertToDto(savedPost);
+    }
+
+    /**
+     * Lấy tất cả các bài viết
+     * @return Danh sách các DTO phản hồi bài viết.
+     */
+    public List<PostResponse> getAllPosts() {
+        return postRepository.findAll().stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Lấy tất cả các bài viết published
+     * @return Danh sách các DTO phản hồi bài viết.
+     */
+    public List<PostResponse> getAllPublishedPosts() {
+        return postRepository.findByStatus("published").stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Lấy một bài viết theo ID.
+     * @param postId ID của bài viết.
+     * @return Optional chứa DTO phản hồi bài viết (nếu tìm thấy).
+     */
+    public Optional<PostResponse> getPostById(Integer postId) {
+        return postRepository.findById(postId)
+                .map(this::convertToDto);
+    }
+
+    /**
+     * Lấy tất cả bài viết của một người dùng cụ thể.
+     * @param userId ID của người dùng.
+     * @return Danh sách DTO phản hồi bài viết của người dùng đó.
+     */
+    public List<PostResponse> getPostsByUserId(Long userId) {
+        return postRepository.findByUser_UserId(userId).stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Cập nhật thông tin một bài viết.
+     * @param postId ID của bài viết cần cập nhật.
+     * @param updateDto DTO chứa thông tin cập nhật.
+     * @param currentUserId ID của người dùng hiện tại (lấy từ ngữ cảnh bảo mật để kiểm tra quyền sở hữu).
+     * @return Optional chứa DTO phản hồi bài viết đã cập nhật (nếu tìm thấy).
+     */
+    @Transactional
+    public Optional<PostResponse> updatePost(Integer postId, PostRequest updateDto, Long currentUserId) {
+        return postRepository.findById(postId)
+                .map(existingPost -> {
+                    // nhớ thêm phân quyền chỗ này giúp anh
+                    if (!existingPost.getUser().getUserId().equals(currentUserId)) {
+                        throw new RuntimeException("Bạn không có quyền sửa bài viết này.");
+                    }
+
+                    existingPost.setTitle(updateDto.getTitle());
+                    existingPost.setContent(updateDto.getContent());
+                    existingPost.setStatus(updateDto.getStatus() != null ? updateDto.getStatus() : existingPost.getStatus());
+
+                    Post updatedPost = postRepository.save(existingPost);
+                    return convertToDto(updatedPost);
+                });
+    }
+
+    /**
+     * Xóa một bài viết
+     * @param postId ID của bài viết cần xóa.
+     * @param currentUserId ID của người dùng hiện tại
+     * @return true nếu xóa thành công, false nếu không tìm thấy bài viết.
+     */
+    @Transactional
+    public boolean deletePost(Integer postId, Long currentUserId) {
+        return postRepository.findById(postId)
+                .map(post -> {
+                    // thêm phân quyền admin hoặc user sở hữu bài viết mới được xoá nha em
+                    if (!post.getUser().getUserId().equals(currentUserId)) {
+                        throw new RuntimeException("Bạn không có quyền xóa bài viết này.");
+                    }
+                    post.setStatus("deleted");
+                    postRepository.save(post);
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    /**
+     * Phương thức hỗ trợ chuyển đổi từ Entity Post sang PostResponseDTO.
+     * @param post Entity Post.
+     * @return PostResponseDTO.
+     */
+    private PostResponse convertToDto(Post post) {
+        return PostResponse.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .postDate(post.getPostDate())
+                .status(post.getStatus())
+                .userId(post.getUser().getUserId())
+                .userName(post.getUser().getUserName())
+                .build();
+    }
+}


### PR DESCRIPTION
This commit introduces full CRUD (Create, Read, Update, Delete) functionality for Posts and Comments, forming the community/blog section of the application.

Key features implemented:

- API endpoints for creating, retrieving (all/by ID/by user), updating, and soft-deleting Posts.

- API endpoints for creating, retrieving (by post/by user), updating, and soft-deleting Comments.

- Posts are managed with 'published' and 'deleted' statuses for content lifecycle.

- Comments are managed with 'active' and 'deleted' statuses.

- Basic ownership checks implemented for updating and deleting Posts/Comments.

New components/logic:

- ,  DTOs for Posts.

- ,  DTOs for Comments.

-  and  with custom query methods.

-  and  containing business logic for CRUD operations.

-  and  exposing RESTful APIs.

Security configuration updated:

-  applied to all Post and Comment APIs for initial testing, to be replaced by / by security module.

- Temporarily hardcoded  in Controllers for testing purposes (MUST BE REVERTED).

This work builds upon previous authentication, member package, and admin user management features.