### PR TITLE
feat(smoking-status): Implement Smoking Status Management (CRUD)

### DIFF
--- a/src/main/java/com/example/smoking_cessation_platform/config/SecurityConfig.java
+++ b/src/main/java/com/example/smoking_cessation_platform/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
-                        // Public APIs
+                        // Public APIs (Authentication related)
                         .requestMatchers("/api/auth/register",
                                 "/api/auth/email/resend-otp",
                                 "/api/auth/email/verify",
@@ -71,9 +71,18 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT, "/api/posts/**/comments/**").permitAll()
                         .requestMatchers(HttpMethod.DELETE, "/api/posts/**/comments/**").permitAll()
 
+                        // SMOKING STATUS APIs
+                        // Temporarily permitAll, needs authentication/ownership checks later
+                        .requestMatchers(HttpMethod.POST, "/api/smoking-status").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/smoking-status/**").permitAll()
+                        .requestMatchers(HttpMethod.PUT, "/api/smoking-status/**").permitAll()
+                        .requestMatchers(HttpMethod.DELETE, "/api/smoking-status/**").permitAll()
+
                         // Any other API requires authentication by default
                         .anyRequest().authenticated()
                 );
+
+        http.authenticationProvider(authenticationProvider());
 
         return http.build();
     }

--- a/src/main/java/com/example/smoking_cessation_platform/controller/SmokingStatusController.java
+++ b/src/main/java/com/example/smoking_cessation_platform/controller/SmokingStatusController.java
@@ -1,0 +1,147 @@
+package com.example.smoking_cessation_platform.controller;
+
+import com.example.smoking_cessation_platform.dto.smokingstatus.SmokingStatusRequest;
+import com.example.smoking_cessation_platform.dto.smokingstatus.SmokingStatusResponse;
+import com.example.smoking_cessation_platform.service.SmokingStatusService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import com.example.smoking_cessation_platform.security.CustomUserDetails;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/smoking-status")
+public class SmokingStatusController {
+
+    @Autowired
+    private SmokingStatusService smokingStatusService;
+
+    /**
+     * API để tạo một bản ghi thói quen hút thuốc mới.
+     * Yêu cầu: POST /api/smoking-status
+     * Body: SmokingStatusCreateUpdateDTO (JSON)
+     * API này yêu cầu người dùng đã được xác thực (đăng nhập).
+     * @param createDto DTO chứa thông tin bản ghi cần tạo.
+     * @param authentication Đối tượng Authentication từ Spring Security.
+     * @return ResponseEntity chứa DTO phản hồi của bản ghi đã được tạo.
+     */
+    @PostMapping
+    public ResponseEntity<SmokingStatusResponse> createSmokingStatus(@Valid @RequestBody SmokingStatusRequest createDto, Authentication authentication) {
+        // nhớ phân quyền
+        Long currentUserId = null;
+        if (authentication.getPrincipal() instanceof CustomUserDetails) {
+            currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        } else {
+            System.err.println("Principal type is not CustomUserDetails for createSmokingStatus. Current type: " + authentication.getPrincipal().getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+
+        try {
+            SmokingStatusResponse newStatus = smokingStatusService.createSmokingStatus(createDto, currentUserId);
+            return ResponseEntity.status(HttpStatus.CREATED).body(newStatus);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
+    }
+
+    /**
+     * API để lấy tất cả các bản ghi thói quen hút thuốc của người dùng đang đăng nhập.
+     * Yêu cầu: GET /api/smoking-status
+     * API này yêu cầu người dùng đã được xác thực (đăng nhập).
+     * @param authentication Đối tượng Authentication từ Spring Security.
+     * @return ResponseEntity chứa danh sách DTO phản hồi bản ghi thói quen hút thuốc.
+     */
+    @GetMapping
+    public ResponseEntity<List<SmokingStatusResponse>> getAllMySmokingStatuses(Authentication authentication) {
+        Long currentUserId = null;
+        if (authentication.getPrincipal() instanceof CustomUserDetails) {
+            currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        } else {
+            System.err.println("Principal type is not CustomUserDetails for getAllMySmokingStatuses. Current type: " + authentication.getPrincipal().getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+
+        List<SmokingStatusResponse> statuses = smokingStatusService.getAllSmokingStatusesByUserId(currentUserId);
+        return ResponseEntity.ok(statuses);
+    }
+
+    /**
+     * API để lấy một bản ghi thói quen hút thuốc theo ID.
+     * Yêu cầu: GET /api/smoking-status/{statusId}
+     * API này yêu cầu người dùng đã được xác thực và là chủ sở hữu bản ghi.
+     * @param statusId ID của bản ghi.
+     * @return ResponseEntity chứa DTO phản hồi bản ghi hoặc NOT_FOUND.
+     */
+    @GetMapping("/{statusId}")
+    public ResponseEntity<SmokingStatusResponse> getSmokingStatusById(@PathVariable Integer statusId) {
+        // phân quyền
+        Optional<SmokingStatusResponse> status = smokingStatusService.getSmokingStatusById(statusId);
+        return status.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * API để cập nhật thông tin một bản ghi thói quen hút thuốc.
+     * Yêu cầu: PUT /api/smoking-status/{statusId}
+     * Body: SmokingStatusCreateUpdateDTO (JSON)
+     * API này yêu cầu người dùng đã được xác thực và là chủ sở hữu bản ghi.
+     * @param statusId ID của bản ghi cần cập nhật.
+     * @param updateDto DTO chứa thông tin cập nhật.
+     * @param authentication Đối tượng Authentication từ Spring Security.
+     * @return ResponseEntity chứa DTO phản hồi bản ghi đã cập nhật hoặc thông báo lỗi.
+     */
+    @PutMapping("/{statusId}")
+    public ResponseEntity<SmokingStatusResponse> updateSmokingStatus(@PathVariable Integer statusId, @Valid @RequestBody SmokingStatusRequest updateDto, Authentication authentication) {
+        Long currentUserId = null;
+        if (authentication.getPrincipal() instanceof CustomUserDetails) {
+            currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        } else {
+            System.err.println("Principal type is not CustomUserDetails for updateSmokingStatus. Current type: " + authentication.getPrincipal().getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+
+        try {
+            Optional<SmokingStatusResponse> updatedStatus = smokingStatusService.updateSmokingStatus(statusId, updateDto, currentUserId);
+            return updatedStatus.map(ResponseEntity::ok)
+                    .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null); // Trả về 403 Forbidden nếu không có quyền
+        }
+    }
+
+    /**
+     * API để xóa một bản ghi thói quen hút thuốc.
+     * Yêu cầu: DELETE /api/smoking-status/{statusId}
+     * API này yêu cầu người dùng đã được xác thực và là chủ sở hữu bản ghi.
+     * @param statusId ID của bản ghi cần xóa.
+     * @param authentication Đối tượng Authentication từ Spring Security.
+     * @return ResponseEntity chứa NO_CONTENT nếu xóa thành công, hoặc NOT_FOUND.
+     */
+    @DeleteMapping("/{statusId}")
+    public ResponseEntity<Void> deleteSmokingStatus(@PathVariable Integer statusId, Authentication authentication) {
+        Long currentUserId = null;
+        if (authentication.getPrincipal() instanceof CustomUserDetails) {
+            currentUserId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        } else {
+            System.err.println("Principal type is not CustomUserDetails for deleteSmokingStatus. Current type: " + authentication.getPrincipal().getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        try {
+            boolean deleted = smokingStatusService.deleteSmokingStatus(statusId, currentUserId);
+            if (deleted) {
+                return ResponseEntity.noContent().build();
+            } else {
+                return ResponseEntity.notFound().build();
+            }
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null); // Trả về 403 Forbidden nếu không có quyền
+        }
+    }
+}

--- a/src/main/java/com/example/smoking_cessation_platform/dto/smokingstatus/SmokingStatusRequest.java
+++ b/src/main/java/com/example/smoking_cessation_platform/dto/smokingstatus/SmokingStatusRequest.java
@@ -1,0 +1,36 @@
+package com.example.smoking_cessation_platform.dto.smokingstatus;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmokingStatusRequest {
+
+    @NotNull(message = "Số điếu thuốc không được để trống")
+    @PositiveOrZero(message = "Số điếu thuốc phải là số không âm")
+    private Integer cigarettesPerDay;
+
+    @Size(max = 255, message = "Tần suất không được vượt quá 255 ký tự")
+    private String frequency;
+
+    private Long packageId;
+
+    @NotNull(message = "Giá mỗi gói không được để trống")
+    @PositiveOrZero(message = "Giá mỗi gói phải là số không âm")
+    private BigDecimal pricePerPack;
+
+    @NotNull(message = "Ngày ghi nhận không được để trống")
+    private LocalDate recordDate;
+
+}

--- a/src/main/java/com/example/smoking_cessation_platform/dto/smokingstatus/SmokingStatusResponse.java
+++ b/src/main/java/com/example/smoking_cessation_platform/dto/smokingstatus/SmokingStatusResponse.java
@@ -1,0 +1,31 @@
+package com.example.smoking_cessation_platform.dto.smokingstatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmokingStatusResponse {
+    private Integer statusId;
+    private Integer cigarettesPerDay;
+    private String frequency;
+    private Long packageId;
+    private String packageName;
+    private BigDecimal pricePerPack;
+    private LocalDate recordDate;
+
+    private Long userId;
+    private String userName;
+    private String userFullName;
+    private String userEmail;
+    private String userPhone;
+    private LocalDateTime userRegistrationDate;
+}

--- a/src/main/java/com/example/smoking_cessation_platform/repository/SmokingStatusRepository.java
+++ b/src/main/java/com/example/smoking_cessation_platform/repository/SmokingStatusRepository.java
@@ -1,9 +1,18 @@
 package com.example.smoking_cessation_platform.repository;
 
 import com.example.smoking_cessation_platform.entity.SmokingStatus;
+import com.example.smoking_cessation_platform.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
 
-public interface SmokingStatusRepository extends JpaRepository<SmokingStatus, Integer>, JpaSpecificationExecutor<SmokingStatus> {
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SmokingStatusRepository extends JpaRepository<SmokingStatus, Integer> {
+    List<SmokingStatus> findByUser_UserId(Long userId);
+
+    Optional<SmokingStatus> findByUserAndRecordDate(User user, LocalDate recordDate);
 
 }

--- a/src/main/java/com/example/smoking_cessation_platform/service/SmokingStatusService.java
+++ b/src/main/java/com/example/smoking_cessation_platform/service/SmokingStatusService.java
@@ -1,0 +1,172 @@
+package com.example.smoking_cessation_platform.service;
+
+import com.example.smoking_cessation_platform.entity.SmokingStatus;
+import com.example.smoking_cessation_platform.entity.User;
+import com.example.smoking_cessation_platform.entity.CigarettePackage;
+import com.example.smoking_cessation_platform.dto.smokingstatus.SmokingStatusRequest;
+import com.example.smoking_cessation_platform.dto.smokingstatus.SmokingStatusResponse;
+import com.example.smoking_cessation_platform.repository.SmokingStatusRepository;
+import com.example.smoking_cessation_platform.repository.UserRepository;
+import com.example.smoking_cessation_platform.repository.CigarettePackageRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class SmokingStatusService {
+
+    @Autowired
+    private SmokingStatusRepository smokingStatusRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CigarettePackageRepository cigarettePackageRepository;
+
+    /**
+     * Tạo một bản ghi thói quen hút thuốc mới.
+     * @param createDto DTO chứa thông tin bản ghi cần tạo.
+     * @param userId ID của người dùng tạo bản ghi (lấy từ ngữ cảnh bảo mật).
+     * @return DTO phản hồi của bản ghi đã được tạo.
+     */
+    @Transactional
+    public SmokingStatusResponse createSmokingStatus(SmokingStatusRequest createDto, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Người dùng không tồn tại."));
+
+
+        if (smokingStatusRepository.findByUserAndRecordDate(user, createDto.getRecordDate()).isPresent()) {
+            throw new RuntimeException("Đã có bản ghi thói quen hút thuốc cho ngày này. Vui lòng cập nhật thay vì tạo mới.");
+        }
+
+        CigarettePackage cigarettePackage = null;
+        if (createDto.getPackageId() != null) {
+            cigarettePackage = cigarettePackageRepository.findById(createDto.getPackageId())
+                    .orElseThrow(() -> new RuntimeException("Gói thuốc lá không tồn tại."));
+        }
+
+        SmokingStatus smokingStatus = SmokingStatus.builder()
+                .cigarettesPerDay(createDto.getCigarettesPerDay())
+                .frequency(createDto.getFrequency())
+                .pricePerPack(createDto.getPricePerPack())
+                .recordDate(createDto.getRecordDate())
+                .user(user)
+                .cigarettePackage(cigarettePackage)
+                .build();
+
+        SmokingStatus savedStatus = smokingStatusRepository.save(smokingStatus);
+        return convertToDto(savedStatus);
+    }
+
+    /**
+     * Lấy tất cả các bản ghi thói quen hút thuốc của một người dùng cụ thể.
+     * @param userId ID của người dùng.
+     * @return Danh sách các DTO phản hồi bản ghi thói quen hút thuốc.
+     */
+    public List<SmokingStatusResponse> getAllSmokingStatusesByUserId(Long userId) {
+        userRepository.findById(userId).orElseThrow(() -> new RuntimeException("Người dùng không tồn tại."));
+        return smokingStatusRepository.findByUser_UserId(userId).stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Lấy một bản ghi thói quen hút thuốc theo ID.
+     * @param statusId ID của bản ghi.
+     * @return Optional chứa DTO phản hồi bản ghi (nếu tìm thấy).
+     */
+    public Optional<SmokingStatusResponse> getSmokingStatusById(Integer statusId) {
+        return smokingStatusRepository.findById(statusId)
+                .map(this::convertToDto);
+    }
+
+    /**
+     * Cập nhật thông tin một bản ghi thói quen hút thuốc.
+     * @param statusId ID của bản ghi cần cập nhật.
+     * @param updateDto DTO chứa thông tin cập nhật.
+     * @param currentUserId ID của người dùng hiện tại (để kiểm tra quyền sở hữu).
+     * @return Optional chứa DTO phản hồi bản ghi đã cập nhật (nếu tìm thấy).
+     */
+    @Transactional
+    public Optional<SmokingStatusResponse> updateSmokingStatus(Integer statusId, SmokingStatusRequest updateDto, Long currentUserId) {
+        return smokingStatusRepository.findById(statusId)
+                .map(existingStatus -> {
+                    // nhớ kiểm tra phân quyền ở đây
+                    if (!existingStatus.getUser().getUserId().equals(currentUserId)) {
+                        throw new RuntimeException("Bạn không có quyền sửa bản ghi này.");
+                    }
+
+                    if (!existingStatus.getRecordDate().equals(updateDto.getRecordDate())) {
+                        User user = existingStatus.getUser();
+                        if (smokingStatusRepository.findByUserAndRecordDate(user, updateDto.getRecordDate()).isPresent()) {
+                            throw new RuntimeException("Đã có bản ghi thói quen hút thuốc cho ngày " + updateDto.getRecordDate() + ". Vui lòng chọn ngày khác.");
+                        }
+                    }
+
+                    CigarettePackage cigarettePackage = null;
+                    if (updateDto.getPackageId() != null) {
+                        cigarettePackage = cigarettePackageRepository.findById(updateDto.getPackageId())
+                                .orElseThrow(() -> new RuntimeException("Gói thuốc lá không tồn tại."));
+                    }
+
+                    existingStatus.setCigarettesPerDay(updateDto.getCigarettesPerDay());
+                    existingStatus.setFrequency(updateDto.getFrequency());
+                    existingStatus.setPricePerPack(updateDto.getPricePerPack());
+                    existingStatus.setRecordDate(updateDto.getRecordDate());
+                    existingStatus.setCigarettePackage(cigarettePackage);
+
+                    SmokingStatus updatedStatus = smokingStatusRepository.save(existingStatus);
+                    return convertToDto(updatedStatus);
+                });
+    }
+
+    /**
+     * Xóa một bản ghi thói quen hút thuốc.
+     * @param statusId ID của bản ghi cần xóa.
+     * @param currentUserId ID của người dùng hiện tại (để kiểm tra quyền sở hữu).
+     * @return true nếu xóa thành công, false nếu không tìm thấy bản ghi.
+     */
+    @Transactional
+    public boolean deleteSmokingStatus(Integer statusId, Long currentUserId) {
+        return smokingStatusRepository.findById(statusId)
+                .map(smokingStatus -> {
+                    // nhớ phân quyền ở đây
+                    if (!smokingStatus.getUser().getUserId().equals(currentUserId)) {
+                        throw new RuntimeException("Bạn không có quyền xóa bản ghi này.");
+                    }
+                    smokingStatusRepository.delete(smokingStatus);
+                    return true;
+                })
+                .orElse(false);
+    }
+
+
+
+    /**
+     * Phương thức hỗ trợ chuyển đổi từ Entity SmokingStatus sang SmokingStatusResponseDTO.
+     * @param smokingStatus Entity SmokingStatus.
+     * @return SmokingStatusResponseDTO.
+     */
+    private SmokingStatusResponse convertToDto(SmokingStatus smokingStatus) {
+        return SmokingStatusResponse.builder()
+                .statusId(smokingStatus.getStatusId())
+                .cigarettesPerDay(smokingStatus.getCigarettesPerDay())
+                .frequency(smokingStatus.getFrequency())
+                .pricePerPack(smokingStatus.getPricePerPack())
+                .recordDate(smokingStatus.getRecordDate())
+                .userId(smokingStatus.getUser().getUserId())
+                .userName(smokingStatus.getUser().getUserName())
+                .userFullName(smokingStatus.getUser().getFullName())
+                .userEmail(smokingStatus.getUser().getEmail())
+                .userPhone(smokingStatus.getUser().getPhone())
+                .userRegistrationDate(smokingStatus.getUser().getRegistrationDate())
+                .packageId(smokingStatus.getCigarettePackage() != null ? smokingStatus.getCigarettePackage().getCigaretteId() : null)
+                .packageName(smokingStatus.getCigarettePackage() != null ? smokingStatus.getCigarettePackage().getCigaretteName() : null)
+                .build();
+    }
+}


### PR DESCRIPTION
This commit introduces full CRUD (Create, Read, Update, Delete) functionality for managing user's daily smoking habits.

Key features implemented:

- API endpoint to create a new smoking status record (POST /api/smoking-status).

- API endpoint to retrieve all smoking status records for the current user (GET /api/smoking-status).

- API endpoint to retrieve a specific smoking status record by ID (GET /api/smoking-status/{statusId}).

- API endpoint to update an existing smoking status record (PUT /api/smoking-status/{statusId}).

- API endpoint to delete a smoking status record (DELETE /api/smoking-status/{statusId}).

New components/logic:

- : DTO for creating and updating records, with validation.

- : DTO for returning record information in API responses.

- : JPA repository with custom query methods (e.g., findByUser_UserId).

- : Business logic for CRUD operations, including ownership checks.

- : REST controller exposing smoking status management APIs.

Security configuration updated:

-  applied to all Smoking Status APIs for initial testing, to be replaced by /ownership checks by security module.

- Temporarily hardcoded  in Controllers for testing purposes (MUST BE REVERTED).

This work builds upon previous authentication, member package, admin user, post, and comment management features.