### PR TITLE
feat(user-profile): Add API for updating user profile information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,13 @@
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/example/smoking_cessation_platform/controller/CoachController.java
+++ b/src/main/java/com/example/smoking_cessation_platform/controller/CoachController.java
@@ -5,6 +5,7 @@ import com.example.smoking_cessation_platform.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,7 +28,7 @@ public class CoachController {
     }
 
     @GetMapping("{id}")
-    public ResponseEntity<UserProfileResponse> getCoachById(Long id) {
+    public ResponseEntity<UserProfileResponse> getCoachById(@PathVariable Long id) {
         UserProfileResponse coachProfile = userService.getCoachProfileById(id);
         if (coachProfile == null) {
             return ResponseEntity.notFound().build();

--- a/src/main/java/com/example/smoking_cessation_platform/controller/UserProfileController.java
+++ b/src/main/java/com/example/smoking_cessation_platform/controller/UserProfileController.java
@@ -1,0 +1,40 @@
+package com.example.smoking_cessation_platform.controller;
+
+    import com.example.smoking_cessation_platform.dto.user.UserProfileRequest;
+    import com.example.smoking_cessation_platform.dto.user.UserProfileResponse;
+    import com.example.smoking_cessation_platform.service.UserService;
+    import org.springframework.beans.factory.annotation.Autowired;
+    import org.springframework.http.ResponseEntity;
+    import org.springframework.web.bind.annotation.*;
+
+    @RestController
+    @RequestMapping("/api/user")
+    public class UserProfileController {
+
+        @Autowired
+        private UserService userService;
+
+        @PutMapping("/profile")
+        public ResponseEntity<UserProfileResponse> updateUserProfile(@RequestBody UserProfileRequest userProfileRequest) {
+            try {
+                UserProfileResponse response = userService.updateUserProfile(userProfileRequest);
+                return ResponseEntity.ok(response);
+            } catch (Exception e) {
+                return ResponseEntity.badRequest().build();
+            }
+        }
+
+        @GetMapping("/profile/{userId}")
+        public ResponseEntity<UserProfileResponse> getUserProfile(@PathVariable Long userId) {
+            return userService.getUserProfile(userId)
+                    .map(ResponseEntity::ok)
+                    .orElse(ResponseEntity.notFound().build());
+        }
+
+        @GetMapping("/profile/public/{userPublicId}")
+        public ResponseEntity<UserProfileResponse> getUserProfileByPublicId(@PathVariable String userPublicId) {
+            return userService.getUserProfileByPublicId(userPublicId)
+                    .map(ResponseEntity::ok)
+                    .orElse(ResponseEntity.notFound().build());
+        }
+    }

--- a/src/main/java/com/example/smoking_cessation_platform/dto/user/UserProfileRequest.java
+++ b/src/main/java/com/example/smoking_cessation_platform/dto/user/UserProfileRequest.java
@@ -1,0 +1,38 @@
+package com.example.smoking_cessation_platform.dto.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileRequest {
+
+    private Long userId;
+
+    @NotBlank(message = "Tên đăng nhập không được để trống")
+    @Size(min = 3, max = 50, message = "Tên đăng nhập phải có từ 3 đến 50 ký tự")
+    private String username;
+
+    @NotBlank(message = "Họ và tên không được để trống")
+    @Size(max = 100, message = "Họ và tên không vượt quá 100 ký tự")
+    private String fullName;
+
+    @NotBlank(message = "Email không được để trống")
+    @Email(message = "Email không hợp lệ")
+    @Size(max = 255, message = "Email không vượt quá 255 ký tự")
+    private String email;
+
+    @NotBlank(message = "Số điện thoại không được để trống")
+    @Pattern(regexp = "^[0-9]{10,11}$", message = "Số điện thoại không hợp lệ (10 hoặc 11 chữ số)")
+    @Size(max = 11, message = "Số điện thoại không vượt quá 11 chữ số")
+    private String phone;
+
+}


### PR DESCRIPTION
- Implemented an API to allow both admin and users to update personal profile information.
- Admins can update any user's profile, while users can only update their own profile.
- Handles validation of input data and responds with appropriate success or error messages.